### PR TITLE
changed the interface to use commands for mloginfo.

### DIFF
--- a/mtools/mloginfo/mloginfo.py
+++ b/mtools/mloginfo/mloginfo.py
@@ -2,29 +2,45 @@
 
 from mtools.util.logfile import LogFile
 from mtools.util.logevent import LogEvent
-from mtools.util.cmdlinetool import LogFileTool
+from mtools.util.cmdlinetool import BaseCmdLineTool, InputSourceAction
 
+import sys
 import inspect
+import argparse
 import mtools.mloginfo.sections as sections
 
 
 
-class MLogInfoTool(LogFileTool):
+class MLogInfoTool(BaseCmdLineTool):
 
     def __init__(self):
         """ Constructor: add description to argparser. """
-        LogFileTool.__init__(self, multiple_logfiles=True, stdin_allowed=False)
-
-        self.argparser.description = 'Extracts general information from logfile and prints it to stdout.'
-        self.argparser.add_argument('--verbose', action='store_true', help='show more verbose output (depends on info section)')
-        self.argparser_sectiongroup = self.argparser.add_argument_group('info sections', 'Below commands activate additional info sections for the log file.')
+        BaseCmdLineTool.__init__(self)
 
         # add all filter classes from the filters module
-        self.sections = [c[1](self) for c in inspect.getmembers(sections, inspect.isclass)]
+        self.sections = dict( [ (c[1].name, c[1](self)) for c in inspect.getmembers(sections, inspect.isclass) ] )
+
+        # initialize arpparser
+        self.argparser.description = 'Extracts general information from logfile and prints it to stdout.'
+        self.argparser.add_argument('--verbose', action='store_true', help='show more verbose output (depends on info section)')
+        
+        # for backwards compatibility, if only a logfile is specified without a command, still print out the basic info
+        # only add command subparsers if there are at least 2 additional arguments (command, logfile) or if --help is invoked
+        if len(sys.argv) != 2 or sys.argv[1] in self.sections.keys() + ['--help', '--version']:
+            # create command sub-parsers
+            subparsers = self.argparser.add_subparsers(title='commands', dest='command')
+
+            for section in self.sections.values():
+                subparser = subparsers.add_parser(section.name, help=section.description, description=section.description)
+                section._add_subparser_arguments(subparser)
+
+        # add logfile action manually at the end
+        self.argparser.add_argument('logfile', action='store', type=InputSourceAction(), nargs='+', help='logfile(s) to parse')
+
 
     def run(self, arguments=None):
         """ Print out useful information about the log file. """
-        LogFileTool.run(self, arguments)
+        BaseCmdLineTool.run(self, arguments)
 
         for i, self.logfile in enumerate(self.args['logfile']):
             if i > 0:
@@ -56,12 +72,12 @@ class MLogInfoTool(LogFileTool):
             print "    version: %s" % version,
             print
 
-            # now run all sections
-            for section in self.sections:
-                if section.active:
-                    print
-                    print section.name.upper()
-                    section.run()
+            # now run requested section
+            if 'command' in self.args:
+                section = self.sections[ self.args['command'] ]
+                print
+                print section.name.upper()
+                section.run()
 
 
 if __name__ == '__main__':

--- a/mtools/mloginfo/sections/base_section.py
+++ b/mtools/mloginfo/sections/base_section.py
@@ -6,7 +6,8 @@ class BaseSection(object):
 
     filterArgs = []
     name = 'base'
-    active = False
+    description = 'description of this section'
+    
 
     def __init__(self, mloginfo):
         """ constructor. save command line arguments and set active to False
@@ -14,8 +15,13 @@ class BaseSection(object):
         """
         # mloginfo object, use it to get access to argparser and other class variables
         self.mloginfo = mloginfo
+        
+    
+    def _add_subparser_arguments(self, subparser):
+        """ add additional subparser arguments in this method if required. """
+        pass
 
-
+    
     def run(self):
         pass
 

--- a/mtools/mloginfo/sections/connection_section.py
+++ b/mtools/mloginfo/sections/connection_section.py
@@ -10,18 +10,7 @@ class ConnectionSection(BaseSection):
     """
     
     name = "connections"
-
-    def __init__(self, mloginfo):
-        BaseSection.__init__(self, mloginfo)
-
-        # add --restarts flag to argparser
-        self.mloginfo.argparser_sectiongroup.add_argument('--connections', action='store_true', help='outputs information about opened and closed connections')
-
-
-    @property
-    def active(self):
-        """ return boolean if this section is active. """
-        return self.mloginfo.args['connections']
+    description = "information about opened and closed connections"
 
 
     def run(self):

--- a/mtools/mloginfo/sections/distinct_section.py
+++ b/mtools/mloginfo/sections/distinct_section.py
@@ -13,19 +13,9 @@ class DistinctSection(BaseSection):
     """
     
     name = "distinct"
+    description = 'distinct list of all log line by message type'
+
     log2code = Log2CodeConverter()
-
-
-    def __init__(self, mloginfo):
-        BaseSection.__init__(self, mloginfo)
-
-        # add --restarts flag to argparser
-        self.mloginfo.argparser_sectiongroup.add_argument('--distinct', action='store_true', help='outputs distinct list of all log line by message type (slow)')
-
-    @property
-    def active(self):
-        """ return boolean if this section is active. """
-        return self.mloginfo.args['distinct']
 
 
     def run(self):

--- a/mtools/mloginfo/sections/query_section.py
+++ b/mtools/mloginfo/sections/query_section.py
@@ -14,18 +14,12 @@ class QuerySection(BaseSection):
     """
     
     name = "queries"
+    description = 'statistics on query shapes per namespace'
 
-    def __init__(self, mloginfo):
-        BaseSection.__init__(self, mloginfo)
-
-        # add --queries flag to argparser
-        self.mloginfo.argparser_sectiongroup.add_argument('--queries', action='store_true', help='outputs statistics about query patterns')
-        self.mloginfo.argparser_sectiongroup.add_argument('--sort', action='store', default='sum', choices=['namespace', 'pattern', 'count', 'min', 'max', 'mean', '95%', 'sum'])
-
-    @property
-    def active(self):
-        """ return boolean if this section is active. """
-        return self.mloginfo.args['queries']
+    
+    def _add_subparser_arguments(self, subparser):
+        """ add additional subparser arguments in this method if required. """
+        subparser.add_argument('--sort', action='store', help='field to sort table rows', default='sum', choices=['namespace', 'pattern', 'count', 'min', 'max', 'mean', '95%', 'sum'])
 
 
     def run(self):

--- a/mtools/mloginfo/sections/restart_section.py
+++ b/mtools/mloginfo/sections/restart_section.py
@@ -9,29 +9,16 @@ class RestartSection(BaseSection):
     """
     
     name = "restarts"
-
-    def __init__(self, mloginfo):
-        BaseSection.__init__(self, mloginfo)
-
-        # add --restarts flag to argparser
-        self.mloginfo.argparser_sectiongroup.add_argument('--restarts', action='store_true', help='outputs information about every detected restart')
-
-
-    @property
-    def active(self):
-        """ return boolean if this section is active. """
-        return self.mloginfo.args['restarts']
+    description = "information about every detected restart"
 
 
     def run(self):
-
         if isinstance(self.mloginfo.logfile, ProfileCollection):
             print
             print "    not available for system.profile collections"
             print
             return
 
-        """ run this section and print out information. """
         for version, logevent in self.mloginfo.logfile.restarts:
             print "   %s version %s" % (logevent.datetime.strftime("%b %d %H:%M:%S"), version)
 


### PR DESCRIPTION
Usage is now:
    mloginfo <command> <logfile> [additional arguments]

Example:
    mloginfo queries mongod.log --sort min

<!--
 To make it easier to review Pull Requests, please provide the details below.
-->

## Description of changes
<!-- Describe the change and related issue(s) if this is not already evident from commit messages -->


## Testing
<!-- Briefly describe how to test the change as well as any testing done before submission -->


O/S testing:
| O/S              | Version(s)
| ---------------- | -----------
| Linux            | 
| macOS            | 
| Windows          |
